### PR TITLE
Fix verification logic to prevent duplicate verifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 A decentralized challenge platform for setting and achieving life goals with rewards.
 
 ## Features
-- Create quests with rewards, timelines and verification requirements
+- Create quests with rewards, timelines and verification requirements 
 - Join quests and submit proof of completion
 - Earn QuestPulse tokens (QPT) for completing quests
 - Stake QPT tokens to create high-value quests
+- Single verification per quest to prevent double-verification
 
 ## Contracts
 - `quest-pulse-token.clar`: Main token contract for QPT
-- `quest-manager.clar`: Core logic for quest creation and management
-- `quest-verification.clar`: Handles verification of quest completion
+- `quest-manager.clar`: Core logic for quest creation and management 
+- `quest-verification.clar`: Handles verification of quest completion and prevents duplicate verifications
 
 ## Getting Started
 [Instructions for local development setup]

--- a/contracts/quest-verification.clar
+++ b/contracts/quest-verification.clar
@@ -13,7 +13,7 @@
 
 (define-public (verify-quest (quest-id uint))
   (begin
-    (asserts! (is-some (map-get? verifications {quest-id: quest-id})) err-already-verified)
+    (asserts! (is-none (map-get? verifications {quest-id: quest-id})) err-already-verified)
     (map-insert verifications
       { quest-id: quest-id }
       {

--- a/tests/quest-verification_test.ts
+++ b/tests/quest-verification_test.ts
@@ -1,0 +1,38 @@
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({
+  name: "Can verify an unverified quest",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const wallet_1 = accounts.get("wallet_1")!;
+    
+    let block = chain.mineBlock([
+      Tx.contractCall("quest-verification", "verify-quest", 
+        [types.uint(1)], 
+        wallet_1.address
+      )
+    ]);
+    
+    assertEquals(block.receipts[0].result, '(ok true)');
+  },
+});
+
+Clarinet.test({
+  name: "Cannot verify an already verified quest", 
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const wallet_1 = accounts.get("wallet_1")!;
+    
+    let block = chain.mineBlock([
+      Tx.contractCall("quest-verification", "verify-quest",
+        [types.uint(1)],
+        wallet_1.address
+      ),
+      Tx.contractCall("quest-verification", "verify-quest", 
+        [types.uint(1)],
+        wallet_1.address
+      )
+    ]);
+
+    assertEquals(block.receipts[1].result, `(err u301)`);
+  },
+});


### PR DESCRIPTION
This PR fixes a critical bug in the quest verification contract where the verification check was incorrectly allowing duplicate verifications of the same quest.

Changes made:
- Fixed the assertion in verify-quest to check for is-none instead of is-some
- Added tests to verify the duplicate verification prevention
- Updated README to document the single verification requirement

The original code was using is-some which would only allow verification if a quest was already verified - the opposite of intended behavior. The fix ensures each quest can only be verified once.

## Testing
New tests have been added to verify:
- A quest can be verified once successfully
- Attempting to verify the same quest twice fails with err-already-verified

No breaking changes were introduced. All existing functionality remains intact with the addition of proper duplicate verification prevention.